### PR TITLE
Switch order of config files

### DIFF
--- a/pywebdriver/__init__.py
+++ b/pywebdriver/__init__.py
@@ -37,12 +37,12 @@ LOCAL_CONFIG_PATH = '%s/../config/config.ini' % os.path.dirname(
     os.path.realpath(__file__))
 PACKAGE_CONFIG_PATH = '/etc/pywebdriver/config.ini'
 
-config_file = LOCAL_CONFIG_PATH
+config_file = PACKAGE_CONFIG_PATH
 if not os.path.isfile(config_file):
-    config_file = PACKAGE_CONFIG_PATH
+    config_file = LOCAL_CONFIG_PATH
 assert os.path.isfile(config_file), (
-    'Could not find config file (looking at %s and %s )' % (
-        LOCAL_CONFIG_PATH, PACKAGE_CONFIG_PATH))
+    'Could not find config file (looking at %s and then %s )' % (
+        PACKAGE_CONFIG_PATH, LOCAL_CONFIG_PATH))
 config = ConfigParser()
 config.read(config_file)
 


### PR DESCRIPTION
It is not a good idea to use the local config file first, because, when you use pywebdriver from git, you always have the default config file provided in the source code, and you don't want to modify this one to avoid having a diff in the source code. So it's better to use the config file in /etc/ first, and then fallback to the local one.