### PR TITLE
Allow selectively loading drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,29 @@ You need to confirmed security exception on your browers for the following paths
 
 see <a href="https://support.mozilla.org/en-US/kb/what-does-your-connection-is-not-secure-mean">here</a> and click on 'Advanced' and 'confirm security exception'
 
+## <a name="browser-settings"></a>Base configuration
+
+#### config.ini file
+It is possible to load selectively drivers you need as some are incompatible.
+
+Add a line in config.ini file like :
+```
+[application]
+drivers=odoo8,cups_driver
+```
+
+If not, default drivers will be loaded:
+
+* cups_driver
+* display_driver
+* escpos_driver
+* serial_driver
+* signature_driver
+* telium_driver
+* opcua_driver
+* odoo7
+* odoo8
+
 ## <a name="browser-settings"></a>Specific configuration
 
 For the customer display **Epson OCD300**, you need to change the config file (config/config.ini).

--- a/pywebdriver/plugins/__init__.py
+++ b/pywebdriver/plugins/__init__.py
@@ -1,9 +1,24 @@
-from . import cups_driver
-from . import display_driver
-from . import escpos_driver
-from . import serial_driver
-from . import signature_driver
-from . import telium_driver
-from . import opcua_driver
-from . import odoo7
-from . import odoo8
+from pywebdriver import config
+
+from ConfigParser import NoOptionError
+from importlib import import_module
+
+DEFAULT_DRIVERS = [
+    'cups_driver',
+    'display_driver',
+    'escpos_driver',
+    'serial_driver',
+    'signature_driver',
+    'telium_driver',
+    'opcua_driver',
+    'odoo7',
+    'odoo8',
+]
+
+try:
+    drivers = config.get('application', 'drivers').split(',')
+except NoOptionError:
+    drivers = DEFAULT_DRIVERS
+
+for driver in drivers:
+    globals()[driver] = import_module('.'+driver, __package__)


### PR DESCRIPTION
This allows to load drivers through config files.

This is required if some drivers are using same controllers functions (like payment terminals - 'payment_transaction_start').

Depends on:

* [ ] #29 (Based on)