### PR TITLE
[IMP] pywebdriver: Allow debug mode with one thread

### DIFF
--- a/config/config.ini.tmpl
+++ b/config/config.ini.tmpl
@@ -23,9 +23,11 @@ host=0.0.0.0
 port=8069
 ; Set the origins allow to commuicate with pywebdriver, default all (*)
 cors_origins=*
-
 ; Enable this value for debug works
 debug=true
+; Set this to false to disable the automatic reloader
+; in Flask's autoreload mechanism conflicts with some driver code
+use_reloader=false
 
 [application]
 ; Set to True if you want that the PyWebDriver Software print a status receipt

--- a/pywebdriver/__init__.py
+++ b/pywebdriver/__init__.py
@@ -85,9 +85,10 @@ if config.getboolean("application", "print_status_start"):
     if "escpos" in drivers:
         drivers["escpos"].push_task("printstatus")
 flask_args = dict(
-    host=config.get("flask", "host"),
-    port=config.getint("flask", "port"),
-    debug=config.getboolean("flask", "debug"),
+    host=config.get("flask", "host", fallback="0.0.0.0"),
+    port=config.getint("flask", "port", fallback=3000),
+    debug=config.getboolean("flask", "debug", fallback=False),
+    use_reloader=config.getboolean("flask", "use_reloader", fallback=False),
     processes=0,
     threaded=True,
 )


### PR DESCRIPTION
As Flask default debug mode will launch another thread, it leads to
unwanted behaviours.

use_reloader=False when debug will solve that.