### PR TITLE
[IMP] Allow get_status receive parameters

### DIFF
--- a/pywebdriver/plugins/cups_driver.py
+++ b/pywebdriver/plugins/cups_driver.py
@@ -71,7 +71,7 @@ class CupsDriver(AbstractDriver):
     def get_vendor_product(self):
         return 'cups-icon'
 
-    def get_status(self):
+    def get_status(self, **params):
         messages = []
         mapstate = {
             3: 'Idle',

--- a/pywebdriver/plugins/display_driver.py
+++ b/pywebdriver/plugins/display_driver.py
@@ -64,7 +64,7 @@ else:
                 time.sleep(duration)
             return render_template('display_status.html')
 
-        def get_status(self):
+        def get_status(self, **params):
             try:
                 self.set_status('connected')
                 # When I use Odoo POS v8, it regularly displays

--- a/pywebdriver/plugins/escpos_driver.py
+++ b/pywebdriver/plugins/escpos_driver.py
@@ -110,7 +110,7 @@ else:
             self.cashdraw(2)
             self.cashdraw(5)
 
-        def get_status(self):
+        def get_status(self, **params):
             messages = []
             self.open_printer()
             if not self.device:

--- a/pywebdriver/plugins/odoo8.py
+++ b/pywebdriver/plugins/odoo8.py
@@ -21,7 +21,6 @@
 ###############################################################################
 
 from flask import request, make_response, jsonify
-
 from pywebdriver import app, config, drivers
 
 
@@ -38,9 +37,11 @@ def handshake_json():
 @app.route('/hw_proxy/status_json', methods=['POST', 'GET', 'PUT'])
 def status_json():
     statuses = {}
+    params = request.json['params']
     for driver in drivers:
-        statuses[driver] = drivers[driver].get_status()
+        statuses[driver] = drivers[driver].get_status(**params)
     return jsonify(jsonrpc='2.0', result=statuses)
+
 
 @app.route('/hw_proxy/log', methods=['POST', 'GET', 'PUT'])
 def log_json():

--- a/pywebdriver/plugins/telium_driver.py
+++ b/pywebdriver/plugins/telium_driver.py
@@ -43,7 +43,7 @@ class TeliumDriver(ThreadDriver, pypostelium.Driver):
             'currency_iso': 'EUR',
         }
 
-    def get_status(self):
+    def get_status(self, **kwargs):
         self.status = {'status': 'connected', 'messages': []}
         # When I use Odoo POS v8, it regularly goes through that code
         # and sends 999.99 to the credit card reader !!!


### PR DESCRIPTION
Allows to pass parameters to the '/hw_proxy/status_json' request
and trasmit them to get_status() function