### PR TITLE
[IMP] Add payment driver base class

### DIFF
--- a/pywebdriver/plugins/payment_base_driver.py
+++ b/pywebdriver/plugins/payment_base_driver.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 #
 #   Copyright (C) 2019 ACSONE SA/NV (https://www.acsone.eu/).
@@ -17,15 +16,15 @@
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ###############################################################################
-from collections import OrderedDict
 import time
+from collections import OrderedDict
 
 from .base_driver import ThreadDriver
 
 
 class LimitedDict(OrderedDict):
-    """ A dictionary that only keeps the last few added keys
-        This serves as a FIFO cache """
+    """A dictionary that only keeps the last few added keys
+    This serves as a FIFO cache"""
 
     def __init__(self, size=20):
         super(LimitedDict, self).__init__()

--- a/pywebdriver/plugins/payment_base_driver.py
+++ b/pywebdriver/plugins/payment_base_driver.py
@@ -1,0 +1,162 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+#   Copyright (C) 2019 ACSONE SA/NV (https://www.acsone.eu/).
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as
+#   published by the Free Software Foundation, either version 3 of the
+#   License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+from collections import OrderedDict
+import time
+
+from .base_driver import ThreadDriver
+
+
+class LimitedDict(OrderedDict):
+    """ A dictionary that only keeps the last few added keys
+        This serves as a FIFO cache """
+
+    def __init__(self, size=20):
+        super(LimitedDict, self).__init__()
+        self._max_size = size
+
+    def __setitem__(self, key, value):
+        if len(self) == self._max_size:
+            self.popitem(last=False)
+        super(LimitedDict, self).__setitem__(key, value)
+
+
+class PaymentTerminalDriver(ThreadDriver):
+    """
+    This is a base driver for payment terminals
+    Properties :
+        * terminals : Adds the ability to serve multiple terminals from
+        one instance of the driver. It is always possible to manage the
+        'classic' way as the default terminal id in that case is '0'.
+        By default, this contains that default '0' terminal.
+    """
+
+    def __init__(self):
+        super(PaymentTerminalDriver, self).__init__()
+        self._terminals = {"0": self._get_default_terminal_values("0")}
+        self._transaction_uuid = int(time.time())
+
+    def _get_default_terminal_values(self, terminal_id):
+        return {
+            "terminal_id": terminal_id,
+            "is_terminal": True,
+            "status": "disconnected",
+            "transactions": LimitedDict(),
+        }
+
+    def _get_default_transaction_values(self, transaction_id):
+        return {
+            "transaction_id": transaction_id,
+            # transaction result
+            # None: unknown, transaction in progress, most probably
+            # True: transaction was successful
+            # False: transaction failed
+            "success": None,
+            # human readable transaction status,
+            # set in case success if False
+            "status": None,
+            # technical details related to the status (in English)
+            "status_details": None,
+            # acquirer reference for the successful transaction,
+            # can be used later for payment file reconciliation
+            "reference": None,
+        }
+
+    def _get_terminal(self, terminal_id):
+        # calls must be guarded by self.lock
+        if terminal_id not in self._terminals:
+            self._terminals[terminal_id] = self._get_default_terminal_values(
+                terminal_id
+            )
+        return self._terminals[terminal_id]
+
+    def _get_transaction(self, terminal_id, transaction_id):
+        # calls must be guarded by self.lock
+        terminal = self._get_terminal(terminal_id)
+        transactions = terminal["transactions"]
+        if transaction_id not in transactions:
+            transactions[transaction_id] = self._get_default_transaction_values(
+                transaction_id
+            )
+        return transactions[transaction_id]
+
+    def _get_last_transaction(self, terminal_id):
+        # calls must be guarded by self.lock
+        terminal = self._get_terminal(terminal_id)
+        transactions = terminal["transactions"]
+        if transactions:
+            return next(reversed(transactions.values()))
+        return None
+
+    def _set_terminal_status(self, terminal_id, status):
+        with self.lock:
+            terminal = self._get_terminal(terminal_id)
+            terminal["status"] = status
+
+    def _make_transaction_uuid(self):
+        """
+        :return: int
+        """
+        with self.lock:
+            self._transaction_uuid += 1
+            return self._transaction_uuid
+
+    def begin_transaction(self, terminal_id):
+        transaction_id = self._make_transaction_uuid()
+        with self.lock:
+            transaction = self._get_transaction(terminal_id, transaction_id)
+            return transaction
+
+    def end_transaction(
+        self,
+        terminal_id,
+        transaction_id,
+        success,
+        status=None,
+        status_details=None,
+        reference=None,
+    ):
+        """Set transaction result.
+
+        If the transaction is not known yet, create a new transaction
+        object to hold the result (typically when the terminal driver
+        has been restarted and we get the last transaction result).
+        If the transaction is done already (success is not None),
+        do nothing.
+
+        If transaction_id is falsy, set the result on the last created
+        transaction.
+        """
+        with self.lock:
+            if transaction_id:
+                transaction = self._get_transaction(terminal_id, transaction_id)
+            else:
+                transaction = self._get_last_transaction(terminal_id)
+            if transaction and transaction.get("success") is None:
+                transaction["success"] = success
+                transaction["status"] = status
+                transaction["status_details"] = status_details
+                transaction["reference"] = reference
+
+    def get_status(self, terminal_id="0", **kwargs):
+        """
+        Return Terminal status
+        """
+        with self.lock:
+            return self._get_terminal(terminal_id)

--- a/pywebdriver/plugins/payment_mock_driver.py
+++ b/pywebdriver/plugins/payment_mock_driver.py
@@ -1,0 +1,60 @@
+import json
+import sys
+
+from flask import request, jsonify
+
+from pywebdriver import app, drivers
+from .payment_base_driver import PaymentTerminalDriver
+
+if sys.version_info < (3,):
+    input = raw_input
+
+
+class PaymentMockDriver(PaymentTerminalDriver):
+    def __init__(self):
+        super(PaymentMockDriver, self).__init__()
+        self._set_terminal_status(terminal_id="0", status="connected")
+
+    def transaction_start(self, data):
+        payment_info = data["payment_info"]
+        transaction_id = data["transaction_id"]
+        terminal_id = payment_info.get("terminal_id", "0")
+        app.logger.info(
+            "payment mock driver transaction start for terminal %s: %s",
+            terminal_id,
+            payment_info,
+        )
+        status = input("status: enter 'ok' for sucess, or any other status: ")
+        if status == "ok":
+            self.end_transaction(
+                terminal_id,
+                transaction_id,
+                success=True,
+            )
+        else:
+            self.end_transaction(
+                terminal_id,
+                transaction_id,
+                success=False,
+                status=status,
+                reference="",
+            )
+
+
+@app.route("/hw_proxy/payment_terminal_transaction_start", methods=["POST"])
+def payment_terminal_transaction_start():
+    # TODO why json in json?
+    payment_info = json.loads(request.json["params"]["payment_info"])
+    terminal_id = payment_info.get("terminal_id", "0")
+    transaction = payment_mock_driver.begin_transaction(terminal_id)
+    payment_mock_driver.push_task(
+        "transaction_start",
+        data=dict(
+            payment_info=payment_info, transaction_id=transaction["transaction_id"]
+        ),
+    )
+    return jsonify(jsonrpc="2.0", result=transaction)
+
+
+payment_mock_driver = PaymentMockDriver()
+drivers["payment_mock_driver"] = payment_mock_driver

--- a/pywebdriver/plugins/payment_mock_driver.py
+++ b/pywebdriver/plugins/payment_mock_driver.py
@@ -1,13 +1,10 @@
 import json
-import sys
 
-from flask import request, jsonify
+from flask import jsonify, request
 
 from pywebdriver import app, drivers
-from .payment_base_driver import PaymentTerminalDriver
 
-if sys.version_info < (3,):
-    input = raw_input
+from .payment_base_driver import PaymentTerminalDriver
 
 
 class PaymentMockDriver(PaymentTerminalDriver):


### PR DESCRIPTION
This would help payment driver implementation as it:

* Initialize transaction values and use them in
  get_status()
* Keep a cache of transactions
* Adds helpers to set terminal state and to add
  succeeded transactions
* Store all values as a dict 'per terminal'. It allows
  to set different kind of architectures without changing
  standard behaviour.