### PR TITLE
Optional logging configuration from the config file

### DIFF
--- a/config/config.ini.tmpl
+++ b/config/config.ini.tmpl
@@ -73,3 +73,31 @@ xonxoff=false
 timeout=5
 eol_cr=true
 eol_lf=true
+
+; if sections loggers, handlers and formatters are present
+; configure the logging module using logging.config.fileConfig
+; see https://docs.python.org/3/library/logging.config.html#logging-config-fileformat
+
+[loggers]
+keys=root
+
+[logger_root]
+level=DEBUG
+handlers=hand01
+
+[handlers]
+keys=hand01
+
+[handler_hand01]
+class=StreamHandler
+level=NOTSET
+formatter=form01
+args=(sys.stdout,)
+
+[formatters]
+keys=form01
+
+[formatter_form01]
+format=%(asctime)s %(levelname)8s %(message)s
+datefmt=
+class=logging.Formatter

--- a/pywebdriver/__init__.py
+++ b/pywebdriver/__init__.py
@@ -24,6 +24,7 @@
 
 # Core Imports
 import gettext
+import logging.config
 import os
 
 from ConfigParser import ConfigParser
@@ -48,6 +49,13 @@ else:
 
 config = ConfigParser()
 config.read(config_file)
+
+if (
+    config.has_section("loggers")
+    and config.has_section("handlers")
+    and config.has_section("formatters")
+):
+    logging.config.fileConfig(config)
 
 drivers = {}
 


### PR DESCRIPTION
If the corrections sections are set in the config file, use them to configure the logging module using [logging.config.fileConfig](https://docs.python.org/3/library/logging.config.html#logging-config-fileformat).