### PR TITLE
telium: return the result of transaction_start

### DIFF
--- a/config/config.ini.tmpl
+++ b/config/config.ini.tmpl
@@ -31,6 +31,11 @@ debug=true
 ; Set to True if you want that the PyWebDriver Software print a status receipt
 ; when the service is started
 print_status_start=false
+; List the drivers to enable
+; You should always enable the driver 'odoo8' if you use Odoo v8+
+; because otherwize the POSbox logo will be red in Odoo POS frontend
+; and nothing will work
+drivers = odoo8,telium_driver,escpos_driver
 
 [odoo]
 ; [7.0] Define default value for the receipt send by Odoo if not defined

--- a/debian/config.ini
+++ b/debian/config.ini
@@ -27,6 +27,10 @@ debug=false
 ; Set to True if you want that the PyWebDriver Software print a status receipt
 ; when the service is started
 print_status_start=false
+; List the drivers to enable
+; You should always enable the driver 'odoo8' if you use Odoo v8+
+; because otherwize the POSbox logo will be red in Odoo POS frontend
+; and nothing will work
 drivers=odoo8,cups_driver,display_driver,escpos_driver
 
 [odoo]

--- a/pywebdriver/plugins/telium_driver.py
+++ b/pywebdriver/plugins/telium_driver.py
@@ -76,8 +76,9 @@ def payment_terminal_transaction_start():
     app.logger.debug('Telium: Call payment_terminal_transaction_start')
     payment_info = request.json['params']['payment_info']
     app.logger.debug('Telium: payment_info=%s', payment_info)
-    telium_driver.push_task('transaction_start', payment_info)
-    return jsonify(jsonrpc='2.0', result=True)
+    result = telium_driver.transaction_start(payment_info)
+    app.logger.debug('Telium: result of transation_start=%s', result)
+    return jsonify(jsonrpc='2.0', result=result)
 
 
 @app.route('/telium_status.html', methods=['POST'])


### PR DESCRIPTION
The goal of this modification is to be able to display an error message
to the user when transation_start() fails
Add comments in config.ini sample files

Requires pypostelium 0.0.4 (but should work with older version, but always returns True)