### PR TITLE
[FIX] Python3.7+ remove call to platform.linux_distribution()

### DIFF
--- a/pywebdriver/views.py
+++ b/pywebdriver/views.py
@@ -84,9 +84,6 @@ def system():
     system_info.append({
         'name': _('OS - System'), 'value': platform.system()})
     system_info.append({
-        'name': _('OS - Distribution'),
-        'value': platform.linux_distribution()})
-    system_info.append({
         'name': _('OS - Release'), 'value': platform.release()})
     system_info.append({
         'name': _('OS - Version'), 'value': platform.version()})


### PR DESCRIPTION
No more platform.linux_distribution() in python3.7+, cf https://github.com/saltstack/salt/issues/37070
Remove related code, to avoid errors.