### PR TITLE
[SEC] by default only listen to 127.0.0.1

### DIFF
--- a/config/config.ini.tmpl
+++ b/config/config.ini.tmpl
@@ -19,7 +19,7 @@ listen=0.0.0.0:8069
 
 [flask]
 ; Set The port of the webserver 'dev' mode
-host=0.0.0.0
+host=127.0.0.1
 port=8069
 ; Set the origins allow to commuicate with pywebdriver, default all (*)
 cors_origins=*

--- a/debian/config.ini
+++ b/debian/config.ini
@@ -15,7 +15,7 @@ keyfile=/etc/ssl/private/ssl-cert-snakeoil.key
 
 [flask]
 ; Set The port of the webserver 'dev' mode
-host=0.0.0.0
+host=127.0.0.1
 port=8069
 ; Set the origins allow to commuicate with pywebdriver, default all (*)
 cors_origins=*


### PR DESCRIPTION
to avoid exposing pywebdriver to the local network.
If needed it can be changed in the config (for a raspberry pi for
instance)