### PR TITLE
Include all translation files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,7 @@ include VERSION
 include README.md
 include requirement.txt
 recursive-include pywebdriver/templates *
-recursive-include pywebdriver/translations/fr/LC_MESSAGES *
+recursive-include pywebdriver/translations *.mo
 recursive-include pywebdriver/static/css *
 recursive-include pywebdriver/static/images *
 recursive-include pywebdriver/static/js *


### PR DESCRIPTION
When german translation where added in #92 the translation files where not added to MANIFEST.in
So after package installation the files are not present.

My suggestion: include all .po and .mo files in MANIFEST.in